### PR TITLE
remove x11-terms/guake from gnome molecules

### DIFF
--- a/molecules/gnome.common
+++ b/molecules/gnome.common
@@ -158,7 +158,6 @@ packages_to_add:
 	x11-misc/magneto-gtk3,
 	x11-misc/xvkbd,
 	x11-terms/gnome-terminal,
-	x11-terms/guake,
 	x11-themes/gnome-icon-theme,
 	x11-themes/gnome-themes,
 	x11-themes/sabayon-artwork-extra,


### PR DESCRIPTION
it doesn't work. at least was not working for me.
and there is gnome extension that does same in more native for gnome3 way
