### PR TITLE
[graphic-environment.common] Add sys-apps/which

### DIFF
--- a/molecules/graphic-environment.common
+++ b/molecules/graphic-environment.common
@@ -13,6 +13,7 @@ packages_to_add:
 	media-libs/mesa,
 	sys-apps/lsb-release,
 	sys-apps/usb_modeswitch,
+	sys-apps/which,
 	x11-apps/xhost,
 	x11-apps/setxkbmap,
 	x11-themes/equinox-themes,


### PR DESCRIPTION
Fix warning from google-chrome:

 /opt/google/chrome/xdg-settings: line 199: which: command not found