### PR TITLE
Update kde.common to add kwallet functions

### DIFF
--- a/molecules/kde.common
+++ b/molecules/kde.common
@@ -86,6 +86,7 @@ packages_to_add:
 	kde-apps/kcharselect,
 	kde-apps/kcolorchooser,
 	kde-plasma/kde-gtk-config,
+	kde-plasma/kwallet-pam
 	kde-plasma/plasma-desktop,
 	kde-plasma/plasma-nm,
 	kde-plasma/plasma-meta,
@@ -122,6 +123,7 @@ packages_to_add:
 	kde-apps/ksquares,
 	kde-apps/ksudoku,
 	kde-apps/kubrick,
+	kde-apps/kwalletmanager,
 	kde-apps/kwrite,
 	kde-apps/libkcddb,
 	kde-apps/libkcompactdisc,

--- a/molecules/kde.common
+++ b/molecules/kde.common
@@ -86,7 +86,7 @@ packages_to_add:
 	kde-apps/kcharselect,
 	kde-apps/kcolorchooser,
 	kde-plasma/kde-gtk-config,
-	kde-plasma/kwallet-pam
+	kde-plasma/kwallet-pam,
 	kde-plasma/plasma-desktop,
 	kde-plasma/plasma-nm,
 	kde-plasma/plasma-meta,


### PR DESCRIPTION
missing kwallet functions due the the change from kwalletd to kde-frameworks/kwallet resulted in a worse experience as the commonly used functions were separated out as optional packages.